### PR TITLE
Only remove card when greater than record count

### DIFF
--- a/CardfileDotNet/CardfileDotNet/UI/CardViewUserControl.cs
+++ b/CardfileDotNet/CardfileDotNet/UI/CardViewUserControl.cs
@@ -194,24 +194,12 @@ namespace CardfileDotNet.UI
 
         private void OnItemDeleted(int index)
         {
-            int front = State.File.FrontIndex;
-            int count = State.File.CardCount;
             if (cardControls.Count < ViewCardCount)
             {
                 RemoveCardControl(index);
-                FullCardMove();
-                return;
             }
 
-            int first = front;
-            int last = (front + ViewCardCount) % count;
-            if ((first < last && (first <= index && index < last)) || (last < first && (first <= index || index < last)))
-            {
-                int baseIndex = index - first;
-                RemoveCardControl(baseIndex);
-                FullCardMove();
-                return;
-            }
+            FullCardAssign();
         }
 
         public void Commit()

--- a/CardfileDotNet/CardfileDotNet/UI/MainForm.cs
+++ b/CardfileDotNet/CardfileDotNet/UI/MainForm.cs
@@ -966,7 +966,7 @@ namespace CardfileDotNet.UI
                 for (int i = 1; i <= State.File.CardCount; ++i)
                 {
                     index = (front + i) % State.File.CardCount;
-                    if (State.File.Cards[index].Index.StartsWith(goToDialog.Value))
+                    if (State.File.Cards[index].Index.StartsWith(goToDialog.Value, StringComparison.OrdinalIgnoreCase))
                     {
                         State.File.FrontIndex = index;
                         return;

--- a/CardfileDotNet/CardfileDotNet/UI/MainForm.cs
+++ b/CardfileDotNet/CardfileDotNet/UI/MainForm.cs
@@ -966,7 +966,7 @@ namespace CardfileDotNet.UI
                 for (int i = 1; i <= State.File.CardCount; ++i)
                 {
                     index = (front + i) % State.File.CardCount;
-                    if (State.File.Cards[index].Index.StartsWith(goToDialog.Value, StringComparison.OrdinalIgnoreCase))
+                    if (State.File.Cards[index].Index.StartsWith(goToDialog.Value))
                     {
                         State.File.FrontIndex = index;
                         return;


### PR DESCRIPTION
On delete there was a crash in
FullCardAssign/FullCardMove because
the cardControls list was shorter than
ViewCardCount. This was in the case where
there were still more records left
than ViewCardCount.

Also, changed the redraw call to FullCardAssgin. The
original call to FullCardMove did not update the UI
cards in either case.